### PR TITLE
Add a basic gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+## Mac
+.DS_Store


### PR DESCRIPTION
Added a basic gitignore for Mac.

@Lutzifer plz merge this PR, and add more items if you think we need. Candidates are as followings:
https://github.com/github/gitignore/blob/master/Ruby.gitignore
https://github.com/github/gitignore/blob/master/Swift.gitignore
