### PR TITLE
Update LICENSE to match that of Swinject.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016 Wolfgang Lutz <wlut@num42.de>
+Copyright (c) 2016 Swinject Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
I want to use "Swinject Contributers" as the license owner to match that of Swinject project if you don't mind. Your contribution is visible [at Contributors page](https://github.com/Swinject/Swinject-CodeGeneration/graphs/contributors) (though the contribution to develop the initial version is invisible).

It's ok to list the names of you guys on README.
