### PR TITLE
use symbols as keys directly; remove old => syntax

### DIFF
--- a/bin/swinject_codegen
+++ b/bin/swinject_codegen
@@ -7,10 +7,10 @@ require_relative "../source/YMLParser"
 require_relative "../source/YMLSerializer"
 
 @options = {
-  :MIGRATION  => false,
-  :CONVERT  => false,
-  :INPUT_FILE => nil,
-  :OUTPUT_FILE => nil
+  MIGRATION: false,
+  CONVERT: false,
+  INPUT_FILE: nil,
+  OUTPUT_FILE: nil
 }
 
 @parser = OptionParser.new do |opts|
@@ -89,8 +89,8 @@ def templates_folder
 end
 
 def write_container_file(input_hash, output_filename)
-  @content_array = input_hash[:DEFINITIONS.to_s]
-  @dependencies = input_hash[:DEPENDENCIES.to_s]
+  @content_array = input_hash[:DEFINITIONS]
+  @dependencies = input_hash[:DEPENDENCIES]
 
   code = ERB.new(File.read("#{templates_folder()}/container.erb"), nil, "-").result
 
@@ -108,14 +108,14 @@ end
 def write_migration_file(input_hash, output_filename)
   @migration_array = []
 
-  input_hash[:DEFINITIONS.to_s].each do |definition|
-    register_function_call_without_last_comma = definition[:register_function_call.to_s].reverse.sub(",", "").reverse
+  input_hash[:DEFINITIONS].each do |definition|
+    register_function_call_without_last_comma = definition[:register_function_call].reverse.sub(",", "").reverse
 
     migration_hash = {
-      :resolve_function_signature_regex.to_s => Shellwords.escape(".#{definition[:resolve_function_signature.to_s].split("->").first.strip}"),
-      :resolve_function_call.to_s => Shellwords.escape("#{definition[:resolve_function_call]})!"),
-      :register_function_signature_regex.to_s => Shellwords.escape(".#{definition[:register_function_signature.to_s].split("(").first}"),
-      :register_function_call.to_s => Shellwords.escape("#{register_function_call_without_last_comma})")
+      :resolve_function_signature_regex => Shellwords.escape(".#{definition[:resolve_function_signature].split("->").first.strip}"),
+      :resolve_function_call => Shellwords.escape("#{definition[:resolve_function_call]})!"),
+      :register_function_signature_regex => Shellwords.escape(".#{definition[:register_function_signature].split("(").first}"),
+      :register_function_call => Shellwords.escape("#{register_function_call_without_last_comma})")
     }
 
     @migration_array.push migration_hash
@@ -136,47 +136,47 @@ def write_migration_file(input_hash, output_filename)
 end
 
 def prepare_definitions(hash)
-  definitions = hash[:DEFINITIONS.to_s]
+  definitions = hash[:DEFINITIONS]
 
   definitions.each do |definition|
-    name = definition[:name.to_s]
+    name = definition[:name]
 
     has_no_name = (name.nil? || name.empty?)
-    argument_hashes = definition[:arguments.to_s]
+    argument_hashes = definition[:arguments]
 
     register_function_signature = "register"
-    register_function_signature << definition[:component.to_s].gsub("<", "").gsub(">", "").gsub(".", "")
+    register_function_signature << definition[:component].gsub("<", "").gsub(">", "").gsub(".", "")
     register_function_signature << "_#{name}" unless has_no_name
     register_function_signature << "(registerClosure: (resolver: ResolverType"
     register_function_signature << ", " unless (argument_hashes.nil? || argument_hashes.empty?)
-    register_function_signature << argument_hashes.map {|a| "#{a[:argument_name.to_s]}: #{a[:argument_type.to_s]}"}.join(", ") unless (argument_hashes.nil? || argument_hashes.empty?)
-    register_function_signature << ") -> (#{definition[:component.to_s]})) -> ServiceEntry<#{definition[:service.to_s]}>"
+    register_function_signature << argument_hashes.map {|a| "#{a[:argument_name]}: #{a[:argument_type]}"}.join(", ") unless (argument_hashes.nil? || argument_hashes.empty?)
+    register_function_signature << ") -> (#{definition[:component]})) -> ServiceEntry<#{definition[:service]}>"
 
     register_function_call = ".register("
-    register_function_call << "#{definition[:service.to_s]}.self,"
+    register_function_call << "#{definition[:service]}.self,"
     register_function_call << " name: \"#{name}\"," unless has_no_name
 
     resolve_function_signature = "resolve"
-    resolve_function_signature << definition[:component.to_s].gsub("<", "").gsub(">", "").gsub(".", "")
+    resolve_function_signature << definition[:component].gsub("<", "").gsub(">", "").gsub(".", "")
     resolve_function_signature << "_#{name}" unless has_no_name
     resolve_function_signature << "("
-    resolve_function_signature << argument_hashes.each_with_index.map {|a,i| "#{a[:argument_name.to_s] + ' ' if i==0}#{a[:argument_name.to_s]}: #{a[:argument_type.to_s]}"}.join(", ") unless (argument_hashes.nil? || argument_hashes.empty?)
-    resolve_function_signature << ") -> #{definition[:component.to_s]}"
+    resolve_function_signature << argument_hashes.each_with_index.map {|a,i| "#{a[:argument_name] + ' ' if i==0}#{a[:argument_name]}: #{a[:argument_type]}"}.join(", ") unless (argument_hashes.nil? || argument_hashes.empty?)
+    resolve_function_signature << ") -> #{definition[:component]}"
 
     resolve_function_call = ".resolve("
-    resolve_function_call << "#{definition[:service.to_s]}.self"
+    resolve_function_call << "#{definition[:service]}.self"
     resolve_function_call << ", name: \"#{name}\"" unless has_no_name
 
-    definition[:resolve_function_signature.to_s] = resolve_function_signature
-    definition[:resolve_function_call.to_s] = resolve_function_call
-    definition[:register_function_signature.to_s] = register_function_signature
-    definition[:register_function_call.to_s] = register_function_call
+    definition[:resolve_function_signature] = resolve_function_signature
+    definition[:resolve_function_call] = resolve_function_call
+    definition[:register_function_signature] = register_function_signature
+    definition[:register_function_call] = register_function_call
   end
 end
 
 def serialize_hash_to_CSV(hash, output_filename)
-  @content_array = hash[:DEFINITIONS.to_s]
-  @dependencies = hash[:DEPENDENCIES.to_s]
+  @content_array = hash[:DEFINITIONS]
+  @dependencies = hash[:DEPENDENCIES]
 
   code = ERB.new(File.read("#{templates_folder}/csv.erb"), nil, "-").result
 

--- a/bin/swinject_codegen
+++ b/bin/swinject_codegen
@@ -112,10 +112,10 @@ def write_migration_file(input_hash, output_filename)
     register_function_call_without_last_comma = definition[:register_function_call].reverse.sub(",", "").reverse
 
     migration_hash = {
-      :resolve_function_signature_regex => Shellwords.escape(".#{definition[:resolve_function_signature].split("->").first.strip}"),
-      :resolve_function_call => Shellwords.escape("#{definition[:resolve_function_call]})!"),
-      :register_function_signature_regex => Shellwords.escape(".#{definition[:register_function_signature].split("(").first}"),
-      :register_function_call => Shellwords.escape("#{register_function_call_without_last_comma})")
+      resolve_function_signature_regex: Shellwords.escape(".#{definition[:resolve_function_signature].split("->").first.strip}"),
+      resolve_function_call: Shellwords.escape("#{definition[:resolve_function_call]})!"),
+      register_function_signature_regex: Shellwords.escape(".#{definition[:register_function_signature].split("(").first}"),
+      register_function_call: Shellwords.escape("#{register_function_call_without_last_comma})")
     }
 
     @migration_array.push migration_hash

--- a/erb/container.erb
+++ b/erb/container.erb
@@ -8,16 +8,16 @@ import  <%= dependency %>
 
 extension Resolvable {
 <% @content_array.each do |hash| %>
-    func <%= hash[:resolve_function_signature.to_s] %> {
-        return self<%= hash[:resolve_function_call.to_s] %><%= ", argument: #{hash[:arguments.to_s][0][:argument_name.to_s]}" if !hash[:arguments.to_s].nil? && hash[:arguments.to_s].count == 1 -%><%= ", arguments: (#{hash[:arguments.to_s].map {|a| a[:argument_name.to_s]}.join(', ')})" if !hash[:arguments.to_s].nil? && hash[:arguments.to_s].count > 1 -%>)<%=hash[:service.to_s] != hash[:component.to_s] ? " as! #{hash[:component.to_s]}" : "!"%>
+    func <%= hash[:resolve_function_signature] %> {
+        return self<%= hash[:resolve_function_call] %><%= ", argument: #{hash[:arguments][0][:argument_name]}" if !hash[:arguments].nil? && hash[:arguments].count == 1 -%><%= ", arguments: (#{hash[:arguments].map {|a| a[:argument_name]}.join(', ')})" if !hash[:arguments].nil? && hash[:arguments].count > 1 -%>)<%=hash[:service] != hash[:component] ? " as! #{hash[:component]}" : "!"%>
     }
 <% end -%>
 }
 
 extension Container {
 <% @content_array.each do |hash| %>
-    func <%= hash[:register_function_signature.to_s] %> {
-        return self<%= hash[:register_function_call.to_s] %> factory: registerClosure)
+    func <%= hash[:register_function_signature] %> {
+        return self<%= hash[:register_function_call] %> factory: registerClosure)
     }
 <% end -%>
 }

--- a/erb/csv.erb
+++ b/erb/csv.erb
@@ -2,5 +2,5 @@
 # ADD_DEPENDENCY <%= dependency %>
 <% end -%>
 <% @content_array.each do |hash| -%>
-<%=hash[:service.to_s] unless hash[:service.to_s].nil? %>; <%= hash[:component.to_s] unless hash[:component.to_s].nil? %> ; <%= hash[:name.to_s] unless hash[:name.to_s].nil? %> ; <%= hash[:arguments.to_s].map {|a| "#{a[:argument_name.to_s]}: #{a[:argument_type.to_s]}"}.join("; ") unless hash[:arguments.to_s].nil? %>
+<%=hash[:service] unless hash[:service].nil? %>; <%= hash[:component] unless hash[:component].nil? %> ; <%= hash[:name] unless hash[:name].nil? %> ; <%= hash[:arguments].map {|a| "#{a[:argument_name]}: #{a[:argument_type]}"}.join("; ") unless hash[:arguments].nil? %>
 <% end -%>

--- a/erb/migration.erb
+++ b/erb/migration.erb
@@ -4,8 +4,8 @@ while IFS= read -r filename
 do
     LC_ALL=C sed -i "" \
     <% @migration_array.each do |hash| -%>
-    -e s/<%=hash[:resolve_function_call.to_s]%>/<%=hash[:resolve_function_signature_regex.to_s]%>/g \
-        -e s/<%=hash[:register_function_call.to_s]%>/<%=hash[:register_function_signature_regex.to_s]%>/g \
+    -e s/<%=hash[:resolve_function_call]%>/<%=hash[:resolve_function_signature_regex]%>/g \
+        -e s/<%=hash[:register_function_call]%>/<%=hash[:register_function_signature_regex]%>/g \
     <% end -%> "$filename"
 done < swiftindex.temp
 rm swiftindex.temp

--- a/source/CSVParser.rb
+++ b/source/CSVParser.rb
@@ -2,8 +2,8 @@ class CSVParser
 
   def parse_CSV(input_filename)
     result_hash = {
-      :DEPENDENCIES.to_s => [],
-      :DEFINITIONS.to_s => []
+      DEPENDENCIES: [],
+      DEFINITIONS: []
     }
 
     f = File.open(input_filename)
@@ -14,9 +14,9 @@ class CSVParser
       elsif line.start_with?("#")
         # detect command
         if(line.start_with?("#ADD_DEPENDENCY "))
-          result_hash[:DEPENDENCIES.to_s].push(line.split(" ")[1])
+          result_hash[:DEPENDENCIES].push(line.split(" ")[1])
         elsif(line.start_with?("# ADD_DEPENDENCY "))
-          result_hash[:DEPENDENCIES.to_s].push(line.split(" ")[2])
+          result_hash[:DEPENDENCIES].push(line.split(" ")[2])
         end
       elsif line.start_with?("//")
         # ignores comments
@@ -30,13 +30,13 @@ class CSVParser
             hash = nil
             if(a.include?(":"))
               hash = {
-                :argument_name.to_s => a.split(":").first.strip,
-                :argument_type.to_s => a.split(":").last.strip
+                argument_name: a.split(":").first.strip,
+                argument_type: a.split(":").last.strip
               }
             else
               hash = {
-                :argument_name.to_s => a.downcase,
-                :argument_type.to_s => a
+                argument_name: a.downcase,
+                argument_type: a
               }
             end
             hash
@@ -48,13 +48,13 @@ class CSVParser
         name = array[2]
 
         hash = {
-          :service.to_s => service,
-          :component.to_s => component,
-          :name.to_s => name,
-          :arguments.to_s => argument_hashes
+          service: service,
+          component: component,
+          name: name,
+          arguments: argument_hashes
         }
 
-        result_hash[:DEFINITIONS.to_s].push hash
+        result_hash[:DEFINITIONS].push hash
       end
     end
     return result_hash


### PR DESCRIPTION
=> is for ruby versions < 1.9 which is irrelevant for us as we rely on the command line parser shipped with 2.0
