### PR TITLE
fix typos using misspell

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ We currently use the code generation in two medium-sized apps across tvOS and iO
 We found our code to become much more convenient to read and write, due to reduced duplication and autocompletion.
 We also have a much better overview the classes available through dependency injection.
 Changing some definition immediately leads to information, where an error will occur.
-We were able to replace all our occurences of `.resolve(` and `.register(` using the current implementation.
+We were able to replace all our occurrences of `.resolve(` and `.register(` using the current implementation.
 
 ## Contributors
 The original idea for combining CodeGeneration and Swinject came from [Daniel Dengler](https://github.com/ddengler), [David Kraus](https://github.com/davidkraus) and [Wolfgang Lutz](https://github.com/lutzifer).

--- a/Support/README.erb
+++ b/Support/README.erb
@@ -245,7 +245,7 @@ We currently use the code generation in two medium-sized apps across tvOS and iO
 We found our code to become much more convenient to read and write, due to reduced duplication and autocompletion.
 We also have a much better overview the classes available through dependency injection.
 Changing some definition immediately leads to information, where an error will occur.
-We were able to replace all our occurences of `.resolve(` and `.register(` using the current implementation.
+We were able to replace all our occurrences of `.resolve(` and `.register(` using the current implementation.
 
 ## Contributors
 The original idea for combining CodeGeneration and Swinject came from [Daniel Dengler](https://github.com/ddengler), [David Kraus](https://github.com/davidkraus) and [Wolfgang Lutz](https://github.com/lutzifer).

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,4 +1,4 @@
-# Customise this file, documentation can be found here:
+# Customize this file, documentation can be found here:
 # https://github.com/fastlane/fastlane/tree/master/fastlane/docs
 # All available actions: https://docs.fastlane.tools/actions
 # can also be listed using the `fastlane actions` command


### PR DESCRIPTION
This PR is part of a campaign to fix a lot of typos on github using https://github.com/client9/misspell!
You can see the progress on https://github.com/fixTypos/fix_typos/
